### PR TITLE
fix(venue-check): load missing script

### DIFF
--- a/views/new-show/venue-check.ejs
+++ b/views/new-show/venue-check.ejs
@@ -1,5 +1,9 @@
 <% layout('layouts/boilerplate') %><%- include('../partials/header') %>
 
+<script
+src="https://api.mapbox.com/mapbox-gl-js/v2.7.0/mapbox-gl.js"
+></script>
+
 <div id="map"></div>
 
 <script>


### PR DESCRIPTION
Make sure the Mapbox script is loaded on the venue-check page.